### PR TITLE
Port over existing abstract datastore implementation

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+node_modules/*
+test/*
+coverage/*

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,9 @@
+{
+    "extends": "@vimeo/eslint-config-player/es6",
+    "env": {
+        "node": true
+    },
+    "rules": {
+        "camelcase": 0,
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ jspm_packages
 
 # Optional REPL history
 .node_repl_history
+
+#OSX
+.DS_Store
+
+*.sublime-workspace

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+test
+.nyc_output
+coverage
+.travis.yml
+.eslintrc
+.eslintignore
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: node_js
+node_js:
+  - "6.9"
+
+script:
+  - npm test
+
+after_success:
+  - npm run coverage

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # tus-datastore-abstract
+[![npm version](https://badge.fury.io/js/tus-datastore-abstract.svg)](https://badge.fury.io/js/tus-datastore-abstract)
+[![Build Status](https://travis-ci.org/tus/tus-datastore-abstract.svg?branch=master)](https://travis-ci.org/tus/tus-datastore-abstract)
+[![Coverage Status](https://coveralls.io/repos/tus/tus-datastore-abstract/badge.svg?branch=master&service=github)](https://coveralls.io/github/tus/tus-datastore-abstract?branch=master)
+[![Dependency Status](https://david-dm.org/tus/tus-datastore-abstract.svg)](https://david-dm.org/tus/tus-datastore-abstract#info=dependencies)
+
+tus is a new open protocol for resumable uploads built on HTTP. This is an abstract class for creating data stores that will work with the tus-node-server implementation.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,3 @@
+const AbstractDataStore = require('./lib/AbstractDataStore');
+
+module.exports = AbstractDataStore;

--- a/lib/AbstractDataStore.js
+++ b/lib/AbstractDataStore.js
@@ -1,0 +1,93 @@
+/**
+ * @fileOverview
+ * Based store for all AbstractDataStore classes.
+ *
+ * @author Ben Stahl <bhstahl@gmail.com>
+ */
+
+const Uid = require('./Uid');
+const File = require('./File');
+const EventEmitter = require('events');
+
+class AbstractDataStore extends EventEmitter {
+    constructor(options) {
+        super();
+        if (!options || !options.path) {
+            throw new TypeError('Store must have a path');
+        }
+        if (options.namingFunction && typeof options.namingFunction !== 'function') {
+            throw new TypeError('namingFunction must be a function');
+        }
+        this.path = options.path;
+        this.generateFileName = options.namingFunction || Uid.rand;
+    }
+
+    get extensions() {
+        if (!this._extensions) {
+            return null;
+        }
+        return this._extensions.join();
+    }
+
+    set extensions(extensions_array) {
+        if (!Array.isArray(extensions_array)) {
+            throw new TypeError('extensions must be an array');
+        }
+        this._extensions = extensions_array;
+    }
+
+    /**
+     * Called in POST requests. This method just creates a
+     * file, implementing the creation extension.
+     *
+     * http://tus.io/protocols/resumable-upload.html#creation
+     *
+     * @param  {object} req http.incomingMessage
+     * @return {Promise}
+     */
+    create(req) {
+        return new Promise((resolve, reject) => {
+            const file_id = this.generateFileName(req);
+            const file = new File(file_id, req.headers['upload-length'], req.headers['upload-defer-length'], req.headers['upload-metadata']);
+            return resolve(file);
+        });
+    }
+
+    /**
+     * Called in PATCH requests. This method should write data
+     * to the AbstractDataStore file, and possibly implement the
+     * concatenation extension.
+     *
+     * http://tus.io/protocols/resumable-upload.html#concatenation
+     *
+     * @param  {object} req http.incomingMessage
+     * @return {Promise}
+     */
+    write(req) {
+        return new Promise((resolve, reject) => {
+            // Stub resolve for tests
+            const offset = 0;
+            return resolve(offset);
+        });
+    }
+
+    /**
+     * Called in HEAD requests. This method should return the bytes
+     * writen to the AbstractDataStore, for the client to know where to resume
+     * the upload.
+     *
+     * @param  {string} id     filename
+     * @return {Promise}       bytes written
+     */
+    getOffset(id) {
+        return new Promise((resolve, reject) => {
+            if (!id) {
+                throw new Error('ENOENT');
+            }
+
+            return resolve({ size: 0, upload_length: 1 });
+        });
+    }
+}
+
+module.exports = AbstractDataStore;

--- a/lib/File.js
+++ b/lib/File.js
@@ -1,0 +1,25 @@
+/**
+ * @fileOverview
+ * Model for File objects.
+ *
+ * @author Ben Stahl <bhstahl@gmail.com>
+ */
+
+class File {
+    constructor(file_id, upload_length, upload_defer_length, upload_metadata) {
+        if (!file_id) {
+            throw new TypeError('[File] constructor must be given a file_id');
+        }
+
+        if (upload_length === undefined && upload_defer_length === undefined) {
+            throw new TypeError('[File] constructor must be given either a upload_length or upload_defer_length');
+        }
+
+        this.id = `${file_id}`;
+        this.upload_length = upload_length;
+        this.upload_defer_length = upload_defer_length;
+        this.upload_metadata = upload_metadata;
+    }
+}
+
+module.exports = File;

--- a/lib/Uid.js
+++ b/lib/Uid.js
@@ -1,0 +1,17 @@
+/**
+ * @fileOverview
+ * Generate and random UID.
+ *
+ * @author Ben Stahl <bhstahl@gmail.com>
+ */
+
+const crypto = require('crypto');
+const crypto_rand = require('crypto-rand');
+
+class Uid {
+    static rand() {
+        const name = `${new Date().getTime() / crypto_rand.rand()}`;
+        return crypto.createHash('md5').update(name).digest('hex');
+    }
+}
+module.exports = Uid;

--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "tus-datastore-abstract",
   "version": "0.0.1",
   "description": "Abstract Data Store for the tus protocol node.js server",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/bhstahl/tus-datastore-abstract.git"
@@ -25,5 +21,41 @@
   "bugs": {
     "url": "https://github.com/bhstahl/tus-datastore-abstract/issues"
   },
-  "homepage": "https://github.com/bhstahl/tus-datastore-abstract#readme"
+  "homepage": "https://github.com/bhstahl/tus-datastore-abstract#readme",
+  "main": "index.js",
+  "scripts": {
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "lint": "eslint .",
+    "pretest": "npm run lint",
+    "test": "NODE_ENV=test nyc --reporter=html --reporter=text ava"
+  },
+  "engines": {
+    "node": ">=6.0"
+  },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "index.js",
+    "lib/"
+  ],
+  "dependencies": {
+    "crypto-rand": "0.0.2"
+  },
+  "devDependencies": {
+    "@vimeo/eslint-config-player": "^5.0.0",
+    "ava": "^0.18.2",
+    "babel-eslint": "^7.1.1",
+    "coveralls": "^2.12.0",
+    "eslint": "^3.17.1",
+    "eslint-plugin-promise": "^3.5.0",
+    "nyc": "^10.1.2"
+  },
+  "ava": {
+    "files": [
+      "test/*.js"
+    ],
+    "source": [
+      "lib/**/*.js"
+    ]
+  }
 }

--- a/test/Test-AbstractDataStore.js
+++ b/test/Test-AbstractDataStore.js
@@ -1,0 +1,91 @@
+import test from 'ava';
+import AbstractDataStore from '../lib/AbstractDataStore';
+import File from '../lib/File';
+
+const fakeRequest = {
+    headers: {
+        'upload-length': 1,
+        'upload-defer-length': 1,
+        'upload-metadata': 1,
+    },
+};
+
+test('constructor must require a path', (t) => {
+    const error = t.throws(() => {
+        new AbstractDataStore();
+    }, TypeError);
+
+    t.is(error.message, 'Store must have a path');
+});
+
+test('constructor namingFunction must be a function ', (t) => {
+    const error = t.throws(() => {
+        new AbstractDataStore({
+            path: '/files',
+            namingFunction: 'a string',
+        });
+    }, TypeError);
+
+    t.is(error.message, 'namingFunction must be a function');
+});
+
+test('extensions should only set if an array is passed', (t) => {
+    const store = new AbstractDataStore({ path: '/files' });
+
+    const error = t.throws(() => {
+        store.extensions = 'creation, concatenation';
+    }, TypeError);
+
+    t.is(error.message, 'extensions must be an array');
+});
+
+test('extensions should get/set appropriately for the Tus-Extension header', (t) => {
+    const extensions = ['creation', 'concatenation'];
+    const store = new AbstractDataStore({ path: '/files' });
+    t.is(store.extensions, null);
+    store.extensions = extensions;
+    t.is(store.extensions, extensions.join());
+});
+
+test('create() returns a file', async (t) => {
+    const store = new AbstractDataStore({ path: '/files' });
+    const file = await store.create(fakeRequest);
+    t.true(file instanceof File);
+});
+
+test('create() should use a naming function', async (t) => {
+    const fileName = 'myFileName';
+    const namingFunction = (req) => fileName;
+    const store = new AbstractDataStore({
+        path: '/files',
+        namingFunction,
+    });
+    const file = await store.create(fakeRequest);
+    t.is(file.id, fileName);
+});
+
+test('write() resolves a new offset', async (t) => {
+    const store = new AbstractDataStore({ path: '/files' });
+    const offset = await store.write(fakeRequest);
+    t.is(typeof offset, 'number');
+    t.is(offset, 0);
+});
+
+test('getOffset() resolves the current file size', async (t) => {
+    const store = new AbstractDataStore({ path: '/files' });
+    const offset = await store.getOffset(fakeRequest);
+    t.is(typeof offset.size, 'number');
+    t.is(offset.size, 0);
+    t.is(typeof offset.upload_length, 'number');
+    t.is(offset.upload_length, 1);
+});
+
+test('getOffset() should throw an error of file isn‘t found', (t) => {
+    const store = new AbstractDataStore({ path: '/files' });
+    return store.getOffset()
+            .catch((error) => {
+                t.is(error.message, 'ENOENT');
+            });
+
+});
+

--- a/test/Test-File.js
+++ b/test/Test-File.js
@@ -1,0 +1,42 @@
+import test from 'ava';
+import File from '../lib/File';
+
+test('must require a file_name', (t) => {
+    const error = t.throws(() => {
+        new File();
+    }, TypeError);
+
+    t.is(error.message, '[File] constructor must be given a file_id');
+});
+
+test('must be given either a upload_length or upload_defer_length', (t) => {
+    const error = t.throws(() => {
+        new File({
+            file_id: '1234',
+        });
+    }, TypeError);
+
+    t.is(error.message, '[File] constructor must be given either a upload_length or upload_defer_length');
+});
+
+test('should set properties given', (t) => {
+
+    const file_id = '1234';
+    const upload_length = 1234;
+    const upload_defer_length = 1;
+    const upload_metadata = 'metadata';
+
+    const file = new File(
+        file_id,
+        upload_length,
+        upload_defer_length,
+        upload_metadata,
+    );
+
+    t.is(file.id, file_id);
+    t.is(file.upload_length, upload_length);
+    t.is(file.upload_defer_length, upload_defer_length);
+    t.is(file.upload_metadata, upload_metadata);
+});
+
+

--- a/test/Test-Uid.js
+++ b/test/Test-Uid.js
@@ -1,0 +1,8 @@
+import test from 'ava';
+import Uid from '../lib/Uid';
+
+test('returns a 32 char random string', (t) => {
+    const id = Uid.rand();
+    t.is(typeof id, 'string');
+    t.is(id.length, 32);
+});


### PR DESCRIPTION
# What

This is the first step of splitting the tus-node-server DataStore's into separate packages (https://github.com/tus/tus-node-server/issues/61), allowing users to only opt-in for specific file systems. 

For this pull request, I have merely copied over the existing functionality, except for removing the reliance on the server specific [errors & events](https://github.com/tus/tus-node-server/blob/7f7b9b8dc5aaddc672b1488199023e8a65b4de0f/lib/stores/DataStore.js#L13-L14). Those should be implemented at the server level, which will come in a later version, resulting in a version bump for tus-node-server as well.


